### PR TITLE
57202549 scheduled Cleanup

### DIFF
--- a/back-end/serverless.yml
+++ b/back-end/serverless.yml
@@ -467,7 +467,15 @@ functions:
           cors: true
           authorizer:
             name: authorizer
-            arn: ${self:custom.authorizerPool.${self:provider.stage}}                
+            arn: ${self:custom.authorizerPool.${self:provider.stage}}      
+  scheduledCleanup:
+    handler: src/functions/raf/scheduledCleanup.handler
+    timeout: 60
+    events: 
+      - eventBridge:
+          schedule: rate(4 hours)
+          enabled: true
+  
 
 resources:
   - ${file(cloudformation/hosting.yml)}

--- a/back-end/src/functions/raf/scheduledCleanup.js
+++ b/back-end/src/functions/raf/scheduledCleanup.js
@@ -1,0 +1,60 @@
+const aws = require('aws-sdk');
+
+const { Database } = require('../../helpers');
+
+const db = new Database();
+
+const sqs = new aws.SQS();
+
+const terminateInstance = Id =>
+  new Promise(async (resolve, reject) => {
+    try {
+      console.log(`terminating id: ${Id}`);
+      const params = {
+        QueueUrl: process.env.PORTAL_TO_INSTANCE_TERMINATION_QUEUE_URL,
+        MessageBody: 'terminate',
+        MessageAttributes: {
+          instance_id: {
+            DataType: 'String',
+            StringValue: String(Id),
+          },
+        },
+      };
+      await sqs.sendMessage(params).promise();
+      resolve(`success`);
+    } catch (error) {
+      console.log(error);
+    }
+  });
+
+exports.handler = async (event, context) => {
+  try {
+    await db.makeConnection();
+
+    const provisioningEnvironments = await db.query(
+      `SELECT Id, Hour(TIMEDIFF( date(now()), date(Created))) as 'RunningTime' from Environment where Status = 'running'`
+    );
+    console.log(provisioningEnvironments);
+
+    const longRunningInstances = provisioningEnvironments.filter(
+      env => env.RunningTime >= 4
+    );
+    console.log(longRunningInstances);
+
+    const terminationPromises = [];
+
+    if (longRunningInstances.length > 0) {
+      longRunningInstances.forEach(instance => {
+        terminationPromises.push(terminateInstance(instance.Id));
+      });
+
+      Promise.all(
+        terminationPromises.map(prom => prom.catch(e => console.log(e)))
+      );
+    } else {
+      console.log('no long running instances');
+    }
+  } catch (err) {
+    console.log(err);
+  }
+};


### PR DESCRIPTION
this should create the scheduled lambda with event bridge.  I wont be around much tomorrow so we can pull it in monday if you want.  It worked on develop start and get a list of id's for running status and running time > 4 hours, but develop isn't working to start instances at the moment to fully vet.  probably need to update the ami's again 