### PR TITLE
Inset Launch Instance button on Dashboard and make larger

### DIFF
--- a/front-end/src/components/Instance/InstanceHistory.js
+++ b/front-end/src/components/Instance/InstanceHistory.js
@@ -76,10 +76,10 @@ const InstanceHistory = params => {
   return (
     <>
       <div className="relative mb-4 mr-6 bg-blue-600 table-card" style={{ width: '700px', minHeight: '' }}>
-        <div className="flex flex-row items-center justify-between w-full pl-2 mt-2 mb-2">
+        <div className="flex flex-row items-center justify-between w-full pl-2 pr-2 mt-2 mb-2">
           <h5 className="text-gray-200 uppercase">instance history</h5>
           <button
-            className="flex flex-row items-center justify-around whitespace-no-wrap pl-4 pr-4 selected:outline-none btn-gray hover:bg-teal-500 hover:text-gray-200"
+            className="flex flex-row items-center justify-around whitespace-no-wrap pl-4 pr-4 pt-1 pb-1 selected:outline-none btn-gray hover:bg-teal-500 hover:text-gray-200"
             type="button"
             onClick={event => handleLaunch(event)}
           >


### PR DESCRIPTION
Inset now matches the left hand side.

Before:
<img width="720" alt="image" src="https://user-images.githubusercontent.com/816232/87341931-49822200-c542-11ea-8b48-75e98a8b520e.png">

After:
<img width="714" alt="image" src="https://user-images.githubusercontent.com/816232/87341946-4dae3f80-c542-11ea-9cce-ae05a7f9a448.png">

No longer looks so lost (yet squished) in the space.