### PR TITLE
LaunchTable: Decrease title padding and remove footnote margin

### DIFF
--- a/front-end/src/components/Researcher/Launch/LaunchTable.js
+++ b/front-end/src/components/Researcher/Launch/LaunchTable.js
@@ -66,7 +66,7 @@ const LaunchTable = ({ history, handleOpen }) => {
   return (
     <>
       <div className="relative mb-4 bg-blue-600 table-card" style={{ width: '800px', minHeight: '400px' }}>
-        <div className="flex flex-row items-center justify-between pl-8 mt-2 mb-2">
+        <div className="flex flex-row items-center justify-between pl-2 mt-2 mb-2">
           <h5 className="text-gray-200 uppercase">instance configuration</h5>
         </div>
 
@@ -125,7 +125,7 @@ const LaunchTable = ({ history, handleOpen }) => {
           />
         )}
 
-        <p className="py-4 pl-2 ml-6 text-gray-200">
+        <p className="py-4 pl-2 text-gray-200">
           * Provisioned instances are limited to two (2) and will remain active for eight (8) hours before automatic
           instance shutdown. New instances may not be launched until prior instance has been fully terminated.
         </p>


### PR DESCRIPTION
This matches the instance history table on the dashboard.

Before:

<img width="822" alt="image" src="https://user-images.githubusercontent.com/816232/87472460-dd71ed80-c617-11ea-9cc5-ed8054a28fe3.png">

After:

<img width="827" alt="image" src="https://user-images.githubusercontent.com/816232/87472467-e236a180-c617-11ea-9805-84aefdfc69b5.png">
