### PR TITLE
Document use of "su" for root access

### DIFF
--- a/front-end/src/components/Researcher/Learn/Learn.js
+++ b/front-end/src/components/Researcher/Learn/Learn.js
@@ -223,7 +223,7 @@ export default function Learn() {
               </li>
               <li>Security researchers given access to a root shell on system via "su -"</li>
               <li>From a root shell, run "./install-enclaves.sh"</li>
-              <li>AES enclave is exercised via "/ssith/aes-main option infile outfile " with option "-e" for encrypt and "-d" for decrypt.</li>
+              <li>AES enclave is exercised via "/ssith/aes-main option infile outfile" with option "-e" for encrypt and "-d" for decrypt.</li>
               <li>Test PAM enclave via "pamtester testing <username> authenticate."</li>
             </ul>
           </li>


### PR DESCRIPTION
 * Added note to use "su" for root access on MIT platform
 * Removed reference to non-existant nginx auth module

Fixes Issue #387.